### PR TITLE
Week 4 - Distance Between Photos

### DIFF
--- a/main.ipynb
+++ b/main.ipynb
@@ -452,16 +452,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "f7f9334a-6ee1-4aa4-8770-d0f48b36f18b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Baseline dataset_spec: DatasetSpec(overlap=0.7, sidelap=0.7, height=30.48m, scan_area=150x150m, exposure=2ms)\n",
+      "Baseline distances (m) [dx, dy]: [15.16791291 11.38070491]\n",
+      "\n",
+      "Double height\n",
+      " distances: [30.33582583 22.76140983]  ratio to baseline: [2. 2.]\n",
+      "Distance increase factor (should be ~2x): [2. 2.]\n",
+      "\n",
+      "Halve focal length (fx,fy * 0.5)\n",
+      " distances: [30.33582583 22.76140983]  ratio to baseline: [2. 2.]\n",
+      "Distance increase factor (should be ~2x): [2. 2.]\n",
+      "\n",
+      "Half image resolution (pixels)\n",
+      " distances: [7.58395646 5.69035246]  ratio to baseline: [0.5 0.5]\n",
+      "Distance decrease factor (should be ~0.5x): [0.5 0.5]\n"
+     ]
+    }
+   ],
    "source": [
-    "camera_ = copy.copy(camera_x10)\n",
-    "dataset_spec_ = copy.copy(dataset_spec)\n",
+    "print(\"Baseline dataset_spec:\", dataset_spec)\n",
+    "baseline_distances = compute_distance_between_images(camera_x10, dataset_spec)\n",
+    "print(\"Baseline distances (m) [dx, dy]:\", baseline_distances)\n",
     "\n",
-    "computed_distances_ = compute_distance_between_images(camera_, dataset_spec_)\n",
-    "print(f\"Computed distance: {computed_distances_}\")"
+    "# Double height -> expect footprint and distances ~2x\n",
+    "spec_height = copy.copy(dataset_spec)\n",
+    "spec_height.height = dataset_spec.height * 2.0\n",
+    "dist_height = compute_distance_between_images(camera_x10, spec_height)\n",
+    "print(\"\\nDouble height\")\n",
+    "print(\" distances:\", dist_height, \" ratio to baseline:\", dist_height / baseline_distances)\n",
+    "print(\"Distance increase factor (should be ~2x):\", dist_height / baseline_distances)\n",
+    "\n",
+    "# Halve focal length -> expect x2 larger footprint -> distances increase\n",
+    "cam_half_fx = copy.copy(camera_x10)\n",
+    "cam_half_fx.fx *= 0.5\n",
+    "cam_half_fx.fy *= 0.5\n",
+    "dist_half_fx = compute_distance_between_images(cam_half_fx, dataset_spec)\n",
+    "print(\"\\nHalve focal length (fx,fy * 0.5)\")\n",
+    "print(\" distances:\", dist_half_fx, \" ratio to baseline:\", dist_half_fx / baseline_distances)\n",
+    "print(\"Distance increase factor (should be ~2x):\", dist_half_fx / baseline_distances)\n",
+    "\n",
+    "# Halve image resolution -> expect smaller footprint -> distances decrease\n",
+    "cam_half_res = copy.copy(camera_x10)\n",
+    "cam_half_res.image_size_x //= 2\n",
+    "cam_half_res.image_size_y //= 2\n",
+    "dist_half_res = compute_distance_between_images(cam_half_res, dataset_spec)\n",
+    "print(\"\\nHalf image resolution (pixels)\")\n",
+    "print(\" distances:\", dist_half_res, \" ratio to baseline:\", dist_half_res / baseline_distances)\n",
+    "print(\"Distance decrease factor (should be ~0.5x):\", dist_half_res / baseline_distances)"
    ]
   },
   {
@@ -476,6 +521,36 @@
     "Your bonus task is to make the distance computation general. Introduce a double `camera_angle` parameter (which is the angle from the X-axis) in the dataset specification, and work out how to adapt your computation. Feel free to reach out to Ayush to discuss ideas and assumptions!\n",
     "\n",
     "![Non Nadir Footprint](assets/non_nadir_gimbal_angle.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "f80b101d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Footprint at 30.48m with 30° tilt: [50.55970971 43.80435364]\n",
+      "Distance between images (non-nadir, 30° tilt): [15.16791291 13.14130609]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from src.plan_computation import compute_non_nadir_footprint, compute_distance_between_images_non_nadir\n",
+    "\n",
+    "camera_angle_deg = 30\n",
+    "camera_angle_rad = np.deg2rad(camera_angle_deg)\n",
+    "\n",
+    "# Compute for 30 degree tilt\n",
+    "footprint_non_nadir = compute_non_nadir_footprint(camera_x10, dataset_spec.height, camera_angle_rad)\n",
+    "print(f\"Footprint at {dataset_spec.height}m with {camera_angle_deg}° tilt: {footprint_non_nadir}\")\n",
+    "\n",
+    "# Compute the distance between images using the new footprint\n",
+    "distances_non_nadir = compute_distance_between_images_non_nadir(camera_x10, dataset_spec, camera_angle_rad)\n",
+    "print(f\"Distance between images (non-nadir, {camera_angle_deg}° tilt): {distances_non_nadir}\")"
    ]
   },
   {

--- a/main.ipynb
+++ b/main.ipynb
@@ -421,10 +421,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "70b32a91-2577-46ec-bb07-9a0a5fd01243",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computed distance for X10 camera with nominal dataset specs: [15.16791291 11.38070491]\n"
+     ]
+    }
+   ],
    "source": [
     "computed_distances = compute_distance_between_images(camera_x10, dataset_spec)\n",
     "expected_distances = np.array([15.17, 11.38], dtype=np.float32)\n",

--- a/main.ipynb
+++ b/main.ipynb
@@ -452,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "id": "f7f9334a-6ee1-4aa4-8770-d0f48b36f18b",
    "metadata": {},
    "outputs": [

--- a/main.ipynb
+++ b/main.ipynb
@@ -470,7 +470,7 @@
       "Halve focal length (fx,fy * 0.5)\n",
       " distances: [30.33582583 22.76140983]  ratio to baseline: [2. 2.]\n",
       "\n",
-      "Half image resolution (pixels)\n",
+      "Half image size (pixels)\n",
       " distances: [7.58395646 5.69035246]  ratio to baseline: [0.5 0.5]\n"
      ]
     }
@@ -480,14 +480,14 @@
     "baseline_distances = compute_distance_between_images(camera_x10, dataset_spec)\n",
     "print(\"\\nBaseline distances (m) [dx, dy]:\", baseline_distances)\n",
     "\n",
-    "# Double height -> expect footprint and distances ~2x\n",
+    "# Double height\n",
     "spec_height = copy.copy(dataset_spec)\n",
     "spec_height.height = dataset_spec.height * 2.0\n",
     "dist_height = compute_distance_between_images(camera_x10, spec_height)\n",
     "print(\"\\nDouble height\")\n",
     "print(\" distances:\", dist_height, \" ratio to baseline:\", dist_height / baseline_distances)\n",
     "\n",
-    "# Halve focal length -> expect x2 larger footprint -> distances increase\n",
+    "# Halve focal length\n",
     "cam_half_fx = copy.copy(camera_x10)\n",
     "cam_half_fx.fx *= 0.5\n",
     "cam_half_fx.fy *= 0.5\n",
@@ -495,12 +495,12 @@
     "print(\"\\nHalve focal length (fx,fy * 0.5)\")\n",
     "print(\" distances:\", dist_half_fx, \" ratio to baseline:\", dist_half_fx / baseline_distances)\n",
     "\n",
-    "# Halve image resolution -> expect smaller footprint -> distances decrease\n",
+    "# Halve image size\n",
     "cam_half_res = copy.copy(camera_x10)\n",
     "cam_half_res.image_size_x //= 2\n",
     "cam_half_res.image_size_y //= 2\n",
     "dist_half_res = compute_distance_between_images(cam_half_res, dataset_spec)\n",
-    "print(\"\\nHalf image resolution (pixels)\")\n",
+    "print(\"\\nHalf image size (pixels)\")\n",
     "print(\" distances:\", dist_half_res, \" ratio to baseline:\", dist_half_res / baseline_distances)"
    ]
   },
@@ -547,7 +547,7 @@
     "\n",
     "A shorter focal length makes the camera \"wider,\" increasing the ground footprint. Photos can be spaced further apart. Wider lenses allow faster coverage but reduce image detail.\n",
     "\n",
-    "### Halving Image Resolution\n",
+    "### Halving Image Size\n",
     "\n",
     "- **Change:** Image size (pixels) halved in both dimensions.\n",
     "- **Result:** Distances roughly halve\n",
@@ -555,7 +555,7 @@
     "    - dy ≈ 5.69 m  \n",
     "    - Ratio to baseline ≈ 0.5x\n",
     "\n",
-    "Lower resolution means each photo covers less ground, so photos must be taken closer together to maintain coverage. Lowering resolution saves storage but requires denser flight patterns and more photos.\n",
+    "Lower image size means each photo covers less ground, so photos must be taken closer together to maintain coverage. Lowering size saves storage but requires denser flight patterns and more photos.\n",
     "\n",
     "### Summary\n",
     "\n",
@@ -564,7 +564,7 @@
     "| Baseline              | 15.17    | 11.38    | 1x                | Determined by footprint and overlap/sidelap                |\n",
     "| Double Height         | 30.34    | 22.76    | ~2x               | Higher altitude → larger footprint → greater spacing       |\n",
     "| Halve Focal Length    | 30.34    | 22.76    | ~2x               | Wider lens → larger footprint → greater spacing            |\n",
-    "| Halve Image Resolution| 7.58     | 5.69     | ~0.5x             | Lower resolution → smaller footprint → closer spacing      |\n"
+    "| Halve Image Size      | 7.58     | 5.69     | ~0.5x             | Lower resolution → smaller footprint → closer spacing      |\n"
    ]
   },
   {
@@ -583,10 +583,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "f80b101d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Footprint at 30.48m with 30° tilt: [50.55970971 43.80435364]\n",
+      "Distance between images (non-nadir, 30° tilt): [15.16791291 13.14130609]\n"
+     ]
+    }
+   ],
    "source": [
     "from src.plan_computation import compute_non_nadir_footprint, compute_distance_between_images_non_nadir\n",
     "\n",

--- a/main.ipynb
+++ b/main.ipynb
@@ -452,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "f7f9334a-6ee1-4aa4-8770-d0f48b36f18b",
    "metadata": {},
    "outputs": [
@@ -461,26 +461,24 @@
      "output_type": "stream",
      "text": [
       "Baseline dataset_spec: DatasetSpec(overlap=0.7, sidelap=0.7, height=30.48m, scan_area=150x150m, exposure=2ms)\n",
+      "\n",
       "Baseline distances (m) [dx, dy]: [15.16791291 11.38070491]\n",
       "\n",
       "Double height\n",
       " distances: [30.33582583 22.76140983]  ratio to baseline: [2. 2.]\n",
-      "Distance increase factor (should be ~2x): [2. 2.]\n",
       "\n",
       "Halve focal length (fx,fy * 0.5)\n",
       " distances: [30.33582583 22.76140983]  ratio to baseline: [2. 2.]\n",
-      "Distance increase factor (should be ~2x): [2. 2.]\n",
       "\n",
       "Half image resolution (pixels)\n",
-      " distances: [7.58395646 5.69035246]  ratio to baseline: [0.5 0.5]\n",
-      "Distance decrease factor (should be ~0.5x): [0.5 0.5]\n"
+      " distances: [7.58395646 5.69035246]  ratio to baseline: [0.5 0.5]\n"
      ]
     }
    ],
    "source": [
     "print(\"Baseline dataset_spec:\", dataset_spec)\n",
     "baseline_distances = compute_distance_between_images(camera_x10, dataset_spec)\n",
-    "print(\"Baseline distances (m) [dx, dy]:\", baseline_distances)\n",
+    "print(\"\\nBaseline distances (m) [dx, dy]:\", baseline_distances)\n",
     "\n",
     "# Double height -> expect footprint and distances ~2x\n",
     "spec_height = copy.copy(dataset_spec)\n",
@@ -488,7 +486,6 @@
     "dist_height = compute_distance_between_images(camera_x10, spec_height)\n",
     "print(\"\\nDouble height\")\n",
     "print(\" distances:\", dist_height, \" ratio to baseline:\", dist_height / baseline_distances)\n",
-    "print(\"Distance increase factor (should be ~2x):\", dist_height / baseline_distances)\n",
     "\n",
     "# Halve focal length -> expect x2 larger footprint -> distances increase\n",
     "cam_half_fx = copy.copy(camera_x10)\n",
@@ -497,7 +494,6 @@
     "dist_half_fx = compute_distance_between_images(cam_half_fx, dataset_spec)\n",
     "print(\"\\nHalve focal length (fx,fy * 0.5)\")\n",
     "print(\" distances:\", dist_half_fx, \" ratio to baseline:\", dist_half_fx / baseline_distances)\n",
-    "print(\"Distance increase factor (should be ~2x):\", dist_half_fx / baseline_distances)\n",
     "\n",
     "# Halve image resolution -> expect smaller footprint -> distances decrease\n",
     "cam_half_res = copy.copy(camera_x10)\n",
@@ -505,8 +501,70 @@
     "cam_half_res.image_size_y //= 2\n",
     "dist_half_res = compute_distance_between_images(cam_half_res, dataset_spec)\n",
     "print(\"\\nHalf image resolution (pixels)\")\n",
-    "print(\" distances:\", dist_half_res, \" ratio to baseline:\", dist_half_res / baseline_distances)\n",
-    "print(\"Distance decrease factor (should be ~0.5x):\", dist_half_res / baseline_distances)"
+    "print(\" distances:\", dist_half_res, \" ratio to baseline:\", dist_half_res / baseline_distances)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76331550",
+   "metadata": {},
+   "source": [
+    "## Impact of Camera/Flight Parameters on Photo Spacing\n",
+    "\n",
+    "Adjusting flight height, camera focal length, and image resolution directly impacts photo spacing. Pilots can use these relationships to optimize flight plans for coverage, resolution, and efficiency.\n",
+    "\n",
+    "### Baseline Case\n",
+    "\n",
+    "- **Parameters:**  \n",
+    "    - Camera: `camera_x10`  \n",
+    "    - Dataset Spec: `dataset_spec` (height=30.48m, overlap=0.7, sidelap=0.7)\n",
+    "- **Result:**  \n",
+    "    - Baseline distances:  \n",
+    "        - dx = 15.17 m  \n",
+    "        - dy = 11.38 m  \n",
+    "\n",
+    "The spacing is determined by the camera's ground footprint and the required overlap/sidelap. Larger footprints or lower overlap mean greater spacing.\n",
+    "\n",
+    "### Doubling Flight Height\n",
+    "\n",
+    "- **Change:**  \n",
+    "    - Height increased from 30.48m to 60.96m.\n",
+    "- **Result:** Distances roughly double\n",
+    "    - dx ≈ 30.34 m  \n",
+    "    - dy ≈ 22.76 m  \n",
+    "    - Ratio to baseline ≈ 2x\n",
+    "\n",
+    "Increasing flight height increases the ground area captured by each photo (footprint scales linearly with height). Thus, the drone can space photos further apart. Pilots can cover larger areas faster at higher altitudes, but ground resolution decreases.\n",
+    "\n",
+    "### Halving Focal Length\n",
+    "\n",
+    "- **Change:**  \n",
+    "    - Focal length (fx, fy) reduced by half.\n",
+    "- **Result:** Distances roughly double\n",
+    "    - dx ≈ 30.34 m  \n",
+    "    - dy ≈ 22.76 m  \n",
+    "    - Ratio to baseline ≈ 2x\n",
+    "\n",
+    "A shorter focal length makes the camera \"wider,\" increasing the ground footprint. Photos can be spaced further apart. Wider lenses allow faster coverage but reduce image detail.\n",
+    "\n",
+    "### Halving Image Resolution\n",
+    "\n",
+    "- **Change:** Image size (pixels) halved in both dimensions.\n",
+    "- **Result:** Distances roughly halve\n",
+    "    - dx ≈ 7.58 m  \n",
+    "    - dy ≈ 5.69 m  \n",
+    "    - Ratio to baseline ≈ 0.5x\n",
+    "\n",
+    "Lower resolution means each photo covers less ground, so photos must be taken closer together to maintain coverage. Lowering resolution saves storage but requires denser flight patterns and more photos.\n",
+    "\n",
+    "### Summary\n",
+    "\n",
+    "| Change                | dx (m)   | dy (m)   | Ratio to Baseline | Analysis                                                   |\n",
+    "|-----------------------|----------|----------|-------------------|------------------------------------------------------------|\n",
+    "| Baseline              | 15.17    | 11.38    | 1x                | Determined by footprint and overlap/sidelap                |\n",
+    "| Double Height         | 30.34    | 22.76    | ~2x               | Higher altitude → larger footprint → greater spacing       |\n",
+    "| Halve Focal Length    | 30.34    | 22.76    | ~2x               | Wider lens → larger footprint → greater spacing            |\n",
+    "| Halve Image Resolution| 7.58     | 5.69     | ~0.5x             | Lower resolution → smaller footprint → closer spacing      |\n"
    ]
   },
   {
@@ -525,19 +583,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "f80b101d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Footprint at 30.48m with 30° tilt: [50.55970971 43.80435364]\n",
-      "Distance between images (non-nadir, 30° tilt): [15.16791291 13.14130609]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from src.plan_computation import compute_non_nadir_footprint, compute_distance_between_images_non_nadir\n",
     "\n",

--- a/src/plan_computation.py
+++ b/src/plan_computation.py
@@ -41,6 +41,22 @@ def compute_distance_between_images(
 
     return np.array([distance_x, distance_y], dtype=float)
 
+def compute_non_nadir_footprint(camera, height, camera_angle_rad):
+    # Standard nadir footprint
+    footprint = compute_image_footprint_on_surface(camera, height)
+    
+    # Stretch the footprint in the direction of tilt
+    footprint_tilted = footprint.copy()
+
+    # For non-nadir, the footprint on the ground increases by 1/cos(angle) in the direction of tilt
+    footprint_tilted[1] /= np.cos(camera_angle_rad)
+    return footprint_tilted
+
+def compute_distance_between_images_non_nadir(camera, dataset_spec, camera_angle_rad):
+    footprint = compute_non_nadir_footprint(camera, dataset_spec.height, camera_angle_rad)
+    dx = footprint[0] * (1 - dataset_spec.overlap)
+    dy = footprint[1] * (1 - dataset_spec.sidelap)
+    return np.array([dx, dy])
 
 def compute_speed_during_photo_capture(
     camera: Camera, dataset_spec: DatasetSpec, allowed_movement_px: float = 1

--- a/src/plan_computation.py
+++ b/src/plan_computation.py
@@ -22,7 +22,24 @@ def compute_distance_between_images(
     Returns:
         The horizontal and vertical distance between images (as a 2-element array).
     """
-    raise NotImplementedError()
+    # Validate overlap and sidelap
+    overlap = float(dataset_spec.overlap)
+    sidelap = float(dataset_spec.sidelap)
+
+    if not (0.0 <= overlap < 1.0):
+        raise ValueError(f"overlap must be in [0, 1), got {overlap}")
+    if not (0.0 <= sidelap < 1.0):
+        raise ValueError(f"sidelap must be in [0, 1), got {sidelap}")
+
+    # Compute the footprint of a single image on the surface at the height
+    footprint = compute_image_footprint_on_surface(camera, dataset_spec.height)
+    footprint_x, footprint_y = float(footprint[0]), float(footprint[1])
+
+    # Distance between image centers
+    distance_x = footprint_x * (1.0 - overlap)
+    distance_y = footprint_y * (1.0 - sidelap)
+
+    return np.array([distance_x, distance_y], dtype=float)
 
 
 def compute_speed_during_photo_capture(


### PR DESCRIPTION
Implemented and tested the logic for calculating the distance between image centers for aerial mapping, including support for non-nadir (tilted camera) cases:

* Implemented `compute_distance_between_images`, which calculates the horizontal and vertical distance between image centers based on camera specs, flight height, overlap, and sidelap. It includes input validation and uses the image footprint at the given height.
* Added `compute_non_nadir_footprint` and `compute_distance_between_images_non_nadir` to support calculations when the camera is tilted, adjusting the footprint accordingly.